### PR TITLE
UPDATE: convertToMicroUnits to reject NaN and to round floats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index.js",
   "module": "/lib/esm/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,8 @@ export const LIQUIDATION_FEE = 0.025;
 const MINIMUM_COLLATERAL_RATIO = 119;
 
 export const convertToMicroUnits = (val: number): number => {
-  return val * MICRO_UNITS;
+  if (Number.isNaN(val) || !val) throw Error('Invalid input given');
+  return Math.abs(Math.floor(val * MICRO_UNITS))
 };
 
 export const convertFromMicroUnits = (val: number): number => {


### PR DESCRIPTION
Should fix the following problems:

`"code":"INVALID_ARGUMENT","argument":"value","value":"NaN"}`
`"code":"INVALID_ARGUMENT","argument":"value","value":"16359000.000000002"`