### PR TITLE
ADD: method for getting a contract ABI

### DIFF
--- a/examples/VaultOwner.js
+++ b/examples/VaultOwner.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-vars */
-const {Account, Vault} = require('..');
+const {Account, Vault, VAULT_IDS} = require('..');
 const {ask} = require('@reach-sh/stdlib');
 const dotenv = require('dotenv');
 dotenv.config();
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const STABLECOIN = process.env.STABLE_COIN;
   const acc = new Account({mnemonic,
     network: 'TestNet'});

--- a/examples/eventStream.js
+++ b/examples/eventStream.js
@@ -1,11 +1,11 @@
-const {Account} = require('..');
+const {Account, VAULT_IDS} = require('..');
 const dotenv = require('dotenv');
 dotenv.config();
 
 // Example snippet to show how to monitor vault activity using the xBacked SDK.
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const account = new Account({
     mnemonic,
     network: 'TestNet',

--- a/examples/feeCollection.js
+++ b/examples/feeCollection.js
@@ -1,4 +1,4 @@
-const {Account, Vault} = require('..');
+const {Account, Vault, VAULT_IDS} = require('..');
 const {ask} = require('@reach-sh/stdlib');
 const dotenv = require('dotenv');
 dotenv.config();
@@ -6,7 +6,7 @@ dotenv.config();
 
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const account = new Account({
     mnemonic,
     network: 'TestNet',

--- a/examples/getAbi.js
+++ b/examples/getAbi.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-vars */
+const {Account, Vault} = require('..');
+const dotenv = require('dotenv');
+dotenv.config();
+(async () => {
+  const mnemonic = process.env.MNEMONIC;
+  const VAULT_ID = process.env.VAULT_ID;
+  const account = new Account({
+    mnemonic,
+    network: 'TestNet',
+  });
+  const abi = await account.getContractAbi({vaultId: VAULT_ID});
+  console.log(abi);
+})();

--- a/examples/getAbi.js
+++ b/examples/getAbi.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-unused-vars */
-const {Account, Vault} = require('..');
+const {Account, VAULT_IDS} = require('..');
 const dotenv = require('dotenv');
 dotenv.config();
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const account = new Account({
     mnemonic,
     network: 'TestNet',

--- a/examples/getAllAccounts.js
+++ b/examples/getAllAccounts.js
@@ -1,11 +1,11 @@
-const {getAllAccounts, Account, Vault} = require('..');
+const {getAllAccounts, Account, Vault, VAULT_IDS} = require('..');
 const {loadStdlib} = require('@reach-sh/stdlib');
 const dotenv = require('dotenv');
 dotenv.config();
 
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const INDEXER_TOKEN = process.env.INDEXER_TOKEN;
   const account = new Account({
     mnemonic,

--- a/examples/getState.js
+++ b/examples/getState.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-vars */
 const {ask} = require('@reach-sh/stdlib');
-const {Account, Vault} = require('..');
+const {Account, Vault, VAULT_IDS} = require('..');
 const dotenv = require('dotenv');
 dotenv.config();
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const account = new Account({
     mnemonic,
     network: 'TestNet',

--- a/examples/liquidatorBot.js
+++ b/examples/liquidatorBot.js
@@ -11,6 +11,7 @@ const {
   calcCollateralRatioAfterLiquidation,
   LIQUIDATION_FEE,
   getOpenVaults,
+  VAULT_IDS,
 } = require('..'); // Use require('@xbacked-dao/xbacked-sdk'); instead
 const dotenv = require('dotenv');
 dotenv.config();
@@ -79,7 +80,7 @@ const tryLiquidate = async (account, vault, address, remainingDebtTokens) => {
 
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const STABLECOIN = process.env.STABLE_COIN;
   const account = new Account({
     mnemonic,

--- a/examples/redemptions.js
+++ b/examples/redemptions.js
@@ -1,11 +1,11 @@
-const {Account, Vault} = require('..');
+const {Account, Vault, VAULT_IDS} = require('..');
 const {ask} = require('@reach-sh/stdlib');
 const dotenv = require('dotenv');
 dotenv.config();
 
 (async () => {
   const mnemonic = process.env.MNEMONIC;
-  const VAULT_ID = process.env.VAULT_ID;
+  const VAULT_ID = VAULT_IDS.TestNet.algo;
   const proposedAddress = process.env.ADDRESS_FOR_REDEMPTION;
   const account = new Account({
     mnemonic,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index.js",
   "module": "/lib/esm/index.js",

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -25,6 +25,10 @@ export interface AccountInterface {
   networkAccount?: any;
 }
 
+interface AbiInterface {
+  sig: string[];
+}
+
 /**
  * An abstraction of an account on the Algorand
  */
@@ -374,6 +378,15 @@ export class Account {
   }
 
   /**
+   * 
+   * @param params vaultId which indicates the contract we want to interact with
+   */
+  async getContractAbi(params: { vaultId: number }): Promise<AbiInterface> {
+    const ctc = this.reachAccount.contract(backend, params.vaultId);
+    return await ctc.getABI();
+  }
+
+  /**
    * Subscribes to all vault events and calls the provided callbacks when the event is fired
    * @param params An object that contains key vaultId, key createCallback and key transactionCallback
    */
@@ -408,4 +421,4 @@ export class Account {
       });
     }
   }
-}
+} 

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -382,6 +382,7 @@ export class Account {
    * @param params vaultId which indicates the contract we want to interact with
    */
   async getContractAbi(params: { vaultId: number }): Promise<AbiInterface> {
+    await this.initialiseReachAccount();
     const ctc = this.reachAccount.contract(backend, params.vaultId);
     return await ctc.getABI();
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,14 @@ const INTEREST_RATE_DENOMINATOR = 100000000000;
 // float conversion. (CONTRACT MINIMUM - 1)
 const MINIMUM_COLLATERAL_RATIO = 119;
 
+export const VAULT_IDS = {
+  TestNet: {
+    algo: 79758986,
+    gobtc: 0,
+    goeth: 0
+  }
+}
+
 /**
  * Converts number to microunits
  * @param val Number to be converted to microunits


### PR DESCRIPTION
Adds a helper method for retrieving the ABI of a contract.

```js
$ feature/abi-method+ 4s ± node getAbi.js
{
  sigs: [
    'AdminAPI_deprecateVault(byte)byte',
    'AdminAPI_replenishSupply(uint64)byte',
    'FeeCollector_collectFees()byte',
    'FeeCollector_dripInterest(address)byte',
    'FeeCollector_settleInterest()byte',
    'Liquidator_liquidateVault(address,uint64)byte',
    'Oracle_updatePrice(uint64)byte',
    'State_read()(uint64,uint64,byte,uint64,uint64,uint64,uint64,uint64,(byte,byte[32])[2],uint64)',
    'State_readVault(address)(byte,byte[33])',
    'VaultOwner_createVault(uint64,uint64)byte',
    'VaultOwner_depositCollateral(uint64)byte',
    'VaultOwner_mintToken(uint64)byte',
    'VaultOwner_returnVaultDebt(uint64)byte',
    'VaultOwner_withdrawCollateral(uint64)byte',
    'VaultRedeemer_proposeVault(address)byte',
    'VaultRedeemer_redeemVault(address,uint64)byte'
  ]
}

```