### PR TITLE
FIX: ensure all vaultDiscovery functions call initialiseReachAccount

### DIFF
--- a/src/vaultDiscovery.ts
+++ b/src/vaultDiscovery.ts
@@ -68,6 +68,7 @@ export const getCreatedVaults = async (params: {
   endRound?: number;
   timeout?: number;
 }): Promise<VaultCreatedEvent[]> => {
+  await params.account.initialiseReachAccount();
   const ctc = params.account.reachAccount.contract(backend, params.vault.id);
   const announcer = ctc.events.Announcer;
 
@@ -93,6 +94,7 @@ export const getClosedVaults = async (params: {
   endRound?: number;
   timeout?: number;
 }): Promise<VaultClosedEvent[]> => {
+  await params.account.initialiseReachAccount();
   const ctc = params.account.reachAccount.contract(backend, params.vault.id);
   const announcer = ctc.events.Announcer;
 


### PR DESCRIPTION
Reported by `Tobias#9484` on discord

```
Using getOpenVaults works but getCreatedVaults doesnt work (with the same parameters according to the docs. I get an error 

 const ctc = params.account.reachAccount.contract(xbacked_contracts_1.masterVault, params.vault.id);
                                   
TypeError: Cannot read properties of undefined (reading 'contract')
This doesnt work:
const vals = await getCreatedVaults({account: acc, vault});

This works:
const vals = await getOpenVaults({account: acc, vault});
```