### PR TITLE
update: contractState and Asa VAULT

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@babel/types": "^7.16.0",
     "@randlabs/myalgo-connect": "^1.1.1",
-    "@reach-sh/stdlib": "^0.1.10-rc.2",
+    "@reach-sh/stdlib": "^0.1.10-rc.3",
     "@types/jsdom": "^16.2.13",
     "@xbacked-dao/xbacked-contracts": "0.0.17",
     "awesome-typescript-loader": "^5.2.1",

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -30,12 +30,12 @@ export class Vault {
     }
     const vaultState = stateView[1];
     return {
-      constants: {
+      constants: vaultState.constants ? {
         INTEREST_RATE_PER_SECOND: vaultState.constants.INTEREST_RATE_PER_SECOND.toNumber(),
         LIQUIDATION_COLLATERAL_RATIO: vaultState.constants.LIQUIDATION_COLLATERAL_RATIO.toNumber(),
         MINIMUM_COLLATERAL_RATIO: vaultState.constants.MINIMUM_COLLATERAL_RATIO.toNumber(),
         VAULT_INTEREST_RATE: vaultState.constants.VAULT_INTEREST_RATE.toNumber(),
-      },
+      }: undefined,
       hotState: {
         accruedInterest: vaultState.hotState.accruedInterest.toNumber(),
         totalVaultDebt: vaultState.hotState.totalVaultDebt.toNumber(),
@@ -46,6 +46,7 @@ export class Vault {
         deprecated: vaultState.coldState.deprecated,
         redeemableVaults: vaultState.coldState.redeemableVaults.map((v: any[]) => v[1]),
         proposalTime: vaultState.coldState.proposalTime.toNumber(),
+        contractState: vaultState.coldState.contractState.toNumber()
       },
       addresses: {
         govStakersAddress: params.account.reachStdLib.formatAddress(vaultState.addresses.govStakersAddress),

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -30,12 +30,14 @@ export class Vault {
     }
     const vaultState = stateView[1];
     return {
-      constants: vaultState.constants ? {
-        INTEREST_RATE_PER_SECOND: vaultState.constants.INTEREST_RATE_PER_SECOND.toNumber(),
-        LIQUIDATION_COLLATERAL_RATIO: vaultState.constants.LIQUIDATION_COLLATERAL_RATIO.toNumber(),
-        MINIMUM_COLLATERAL_RATIO: vaultState.constants.MINIMUM_COLLATERAL_RATIO.toNumber(),
-        VAULT_INTEREST_RATE: vaultState.constants.VAULT_INTEREST_RATE.toNumber(),
-      }: undefined,
+      constants: vaultState.constants
+        ? {
+            INTEREST_RATE_PER_SECOND: vaultState.constants.INTEREST_RATE_PER_SECOND.toNumber(),
+            LIQUIDATION_COLLATERAL_RATIO: vaultState.constants.LIQUIDATION_COLLATERAL_RATIO.toNumber(),
+            MINIMUM_COLLATERAL_RATIO: vaultState.constants.MINIMUM_COLLATERAL_RATIO.toNumber(),
+            VAULT_INTEREST_RATE: vaultState.constants.VAULT_INTEREST_RATE.toNumber(),
+          }
+        : undefined,
       hotState: {
         accruedInterest: vaultState.hotState.accruedInterest.toNumber(),
         totalVaultDebt: vaultState.hotState.totalVaultDebt.toNumber(),
@@ -46,7 +48,7 @@ export class Vault {
         deprecated: vaultState.coldState.deprecated,
         redeemableVaults: vaultState.coldState.redeemableVaults.map((v: any[]) => v[1]),
         proposalTime: vaultState.coldState.proposalTime.toNumber(),
-        contractState: vaultState.coldState.contractState.toNumber()
+        contractState: vaultState.coldState.contractState.toNumber(),
       },
       addresses: {
         govStakersAddress: params.account.reachStdLib.formatAddress(vaultState.addresses.govStakersAddress),

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -30,14 +30,9 @@ export class Vault {
     }
     const vaultState = stateView[1];
     return {
-      constants: vaultState.constants
-        ? {
-            INTEREST_RATE_PER_SECOND: vaultState.constants.INTEREST_RATE_PER_SECOND.toNumber(),
-            LIQUIDATION_COLLATERAL_RATIO: vaultState.constants.LIQUIDATION_COLLATERAL_RATIO.toNumber(),
-            MINIMUM_COLLATERAL_RATIO: vaultState.constants.MINIMUM_COLLATERAL_RATIO.toNumber(),
-            VAULT_INTEREST_RATE: vaultState.constants.VAULT_INTEREST_RATE.toNumber(),
-          }
-        : undefined,
+      LIQUIDATION_COLLATERAL_RATIO: vaultState.LIQUIDATION_COLLATERAL_RATIO.toNumber(),
+      MINIMUM_COLLATERAL_RATIO: vaultState.MINIMUM_COLLATERAL_RATIO.toNumber(),
+      VAULT_INTEREST_RATE: vaultState.VAULT_INTEREST_RATE.toNumber(),
       hotState: {
         accruedInterest: vaultState.hotState.accruedInterest.toNumber(),
         totalVaultDebt: vaultState.hotState.totalVaultDebt.toNumber(),

--- a/src/VaultClient.ts
+++ b/src/VaultClient.ts
@@ -272,7 +272,7 @@ export class VaultClient extends Account {
       now.toNumber(),
       userVault.lastAccruedInterestTime,
       userVault.vaultDebt,
-      VAULT_INTEREST_RATE ? VAULT_INTEREST_RATE: 2000000000,
+      VAULT_INTEREST_RATE ? VAULT_INTEREST_RATE : 2000000000,
     );
     userVault.vaultDebt += interestAccrued;
     return userVault;

--- a/src/VaultClient.ts
+++ b/src/VaultClient.ts
@@ -266,13 +266,13 @@ export class VaultClient extends Account {
     const userVault = await params.vault.getUserInfo({ account: this, address: params.address });
     // NOTE: does not account for leap year
     const vaultState = await this.getVaultState({ vault: params.vault });
-    const VAULT_INTEREST_RATE = vaultState.constants.VAULT_INTEREST_RATE;
+    const VAULT_INTEREST_RATE = vaultState.constants?.VAULT_INTEREST_RATE;
     const now = await this.reachStdLib.getNetworkSecs();
     const interestAccrued = calculateInterestAccrued(
       now.toNumber(),
       userVault.lastAccruedInterestTime,
       userVault.vaultDebt,
-      VAULT_INTEREST_RATE,
+      VAULT_INTEREST_RATE ? VAULT_INTEREST_RATE: 2000000000,
     );
     userVault.vaultDebt += interestAccrued;
     return userVault;

--- a/src/VaultClient.ts
+++ b/src/VaultClient.ts
@@ -266,7 +266,7 @@ export class VaultClient extends Account {
     const userVault = await params.vault.getUserInfo({ account: this, address: params.address });
     // NOTE: does not account for leap year
     const vaultState = await this.getVaultState({ vault: params.vault });
-    const VAULT_INTEREST_RATE = vaultState.constants?.VAULT_INTEREST_RATE;
+    const VAULT_INTEREST_RATE = vaultState.VAULT_INTEREST_RATE;
     const now = await this.reachStdLib.getNetworkSecs();
     const interestAccrued = calculateInterestAccrued(
       now.toNumber(),

--- a/src/__mock__/MockVaultClient.ts
+++ b/src/__mock__/MockVaultClient.ts
@@ -37,7 +37,7 @@ class MockVaultClient extends VaultClient {
                     deprecated: false,
                     redeemableVaults: [],
                     proposalTime: bigNumberMock(1),
-                    contractState: bigNumberMock(0)
+                    contractState: bigNumberMock(0),
                   },
                   addresses: {
                     govStakersAddress: '0x128a983f12324311e7f85264e9d92e5d02cf9cc87e3cc2ae13095673bd0e05f7',

--- a/src/__mock__/MockVaultClient.ts
+++ b/src/__mock__/MockVaultClient.ts
@@ -21,12 +21,10 @@ class MockVaultClient extends VaultClient {
               return [
                 'Some',
                 {
-                  constants: {
-                    INTEREST_RATE_PER_SECOND: bigNumberMock(1),
-                    LIQUIDATION_COLLATERAL_RATIO: bigNumberMock(1),
-                    MINIMUM_COLLATERAL_RATIO: bigNumberMock(1),
-                    VAULT_INTEREST_RATE: bigNumberMock(1),
-                  },
+                  LIQUIDATION_COLLATERAL_RATIO: bigNumberMock(1),
+                  MINIMUM_COLLATERAL_RATIO: bigNumberMock(1),
+                  VAULT_INTEREST_RATE: bigNumberMock(1),
+
                   hotState: {
                     accruedInterest: bigNumberMock(1),
                     totalVaultDebt: bigNumberMock(1),

--- a/src/__mock__/MockVaultClient.ts
+++ b/src/__mock__/MockVaultClient.ts
@@ -37,6 +37,7 @@ class MockVaultClient extends VaultClient {
                     deprecated: false,
                     redeemableVaults: [],
                     proposalTime: bigNumberMock(1),
+                    contractState: bigNumberMock(0)
                   },
                   addresses: {
                     govStakersAddress: '0x128a983f12324311e7f85264e9d92e5d02cf9cc87e3cc2ae13095673bd0e05f7',

--- a/src/__tests__/xbacked-test.ts
+++ b/src/__tests__/xbacked-test.ts
@@ -96,7 +96,7 @@ it('Get vault Info', async () => {
       deprecated: false,
       redeemableVaults: [],
       proposalTime: 1,
-      contractState: 0
+      contractState: 0,
     },
     addresses: {
       govStakersAddress: 'CKFJQPYSGJBRDZ7YKJSOTWJOLUBM7HGIPY6MFLQTBFLHHPIOAX3VEZQP44',

--- a/src/__tests__/xbacked-test.ts
+++ b/src/__tests__/xbacked-test.ts
@@ -96,6 +96,7 @@ it('Get vault Info', async () => {
       deprecated: false,
       redeemableVaults: [],
       proposalTime: 1,
+      contractState: 0
     },
     addresses: {
       govStakersAddress: 'CKFJQPYSGJBRDZ7YKJSOTWJOLUBM7HGIPY6MFLQTBFLHHPIOAX3VEZQP44',

--- a/src/__tests__/xbacked-test.ts
+++ b/src/__tests__/xbacked-test.ts
@@ -80,12 +80,10 @@ it('Create Reach Account', async function () {
 
 it('Get vault Info', async () => {
   const expectedVaultState = {
-    constants: {
-      INTEREST_RATE_PER_SECOND: 1,
-      LIQUIDATION_COLLATERAL_RATIO: 1,
-      MINIMUM_COLLATERAL_RATIO: 1,
-      VAULT_INTEREST_RATE: 1,
-    },
+    LIQUIDATION_COLLATERAL_RATIO: 1,
+    MINIMUM_COLLATERAL_RATIO: 1,
+    VAULT_INTEREST_RATE: 1,
+
     hotState: {
       accruedInterest: 1,
       totalVaultDebt: 1,

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -63,7 +63,7 @@ export interface VaultReturnParams {
     deprecated: boolean;
     redeemableVaults: any[];
     proposalTime?: number;
-    contractState?: number
+    contractState?: number;
   };
   addresses: {
     govStakersAddress: string;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -47,7 +47,7 @@ export interface StakeLocalView {
 }
 
 export interface VaultReturnParams {
-  constants: {
+  constants?: {
     INTEREST_RATE_PER_SECOND: number;
     LIQUIDATION_COLLATERAL_RATIO: number;
     MINIMUM_COLLATERAL_RATIO: number;
@@ -63,6 +63,7 @@ export interface VaultReturnParams {
     deprecated: boolean;
     redeemableVaults: any[];
     proposalTime?: number;
+    contractState?: number
   };
   addresses: {
     govStakersAddress: string;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -47,12 +47,9 @@ export interface StakeLocalView {
 }
 
 export interface VaultReturnParams {
-  constants?: {
-    INTEREST_RATE_PER_SECOND: number;
-    LIQUIDATION_COLLATERAL_RATIO: number;
-    MINIMUM_COLLATERAL_RATIO: number;
-    VAULT_INTEREST_RATE: number;
-  };
+  LIQUIDATION_COLLATERAL_RATIO: number;
+  MINIMUM_COLLATERAL_RATIO: number;
+  VAULT_INTEREST_RATE: number;
   hotState: {
     accruedInterest: number;
     totalVaultDebt: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,9 +1143,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reach-sh/stdlib@npm:^0.1.10-rc.2":
-  version: 0.1.10-rc.2
-  resolution: "@reach-sh/stdlib@npm:0.1.10-rc.2"
+"@reach-sh/stdlib@npm:^0.1.10-rc.3":
+  version: 0.1.10-rc.3
+  resolution: "@reach-sh/stdlib@npm:0.1.10-rc.3"
   dependencies:
     "@msgpack/msgpack": ^2.5.1
     "@randlabs/myalgo-connect": ^1.1.2
@@ -1161,7 +1161,7 @@ __metadata:
     node-fetch: ^2.6.1
     tslib: ^2.3.1
     wait-port: ^0.2.9
-  checksum: b72699c4cc6db63b1eb953381da99a99d0244c766b7d17c743750cd6a2daf7055033cc191800897e4efa335ac7c4ef17450fa98155886dc7c570259b07c0b61b
+  checksum: 0184a1f8ce78a1b2ea3cf7b3bc6e97bd2163261c3658a1de363a274fa495238ca0557fd4175cef40355135f51cbf51e425ebb36897c2a637b047389cba6c8ed4
   languageName: node
   linkType: hard
 
@@ -1777,7 +1777,7 @@ __metadata:
     "@babel/types": ^7.16.0
     "@jest/globals": ^27.4.6
     "@randlabs/myalgo-connect": ^1.1.1
-    "@reach-sh/stdlib": ^0.1.10-rc.2
+    "@reach-sh/stdlib": ^0.1.10-rc.3
     "@types/jest": ^27.4.0
     "@types/jsdom": ^16.2.13
     "@types/node": ^16.11.9


### PR DESCRIPTION
This branch updates the sdk to use the latest version of reach and also supports the removal of the constants key from the asa vault state