### PR TITLE
ADD: ability for SDK users to supply own environment for node & indexer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index",
   "module": "lib/esm/index",

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -22,9 +22,11 @@ export class Account {
   network?: 'LocalHost' | 'MainNet' | 'TestNet';
   /** @property An instance of the provider object for the signer specified */
   provider?: any;
+  /** @property providerEnv for indexer */
+  providerEnv?: any;
   /** @property An optional instance of an account from the reach standard library. Used to reconnect via a frontend */
   networkAccount?: any;
-
+  /** @property An optional object used to interact with ASA vaults with varying decimals */
   asaVault?: {
     decimals: number;
   };
@@ -35,6 +37,7 @@ export class Account {
     this.secretKey = params.secretKey;
     this.signer = params.signer;
     this.provider = params.provider;
+    this.providerEnv = params.providerEnv;
     this.reachStdLib = params.reachStdLib || loadStdlib('ALGO');
     this.networkAccount = params.networkAccount;
     this.asaVault = params.asaVault;
@@ -60,7 +63,7 @@ export class Account {
     } else if (this.networkAccount && this.signer && this.reachAccount == null && this.provider) {
       await this.reachStdLib.setWalletFallback(
         await this.reachStdLib.walletFallback({
-          providerEnv: this.network,
+          providerEnv: this.providerEnv ? this.providerEnv : this.network,
           [this.signer]: this.provider,
         }),
       );
@@ -68,7 +71,7 @@ export class Account {
     } else if (this.signer && !this.reachAccount && this.provider) {
       await this.reachStdLib.setWalletFallback(
         await this.reachStdLib.walletFallback({
-          providerEnv: this.network,
+          providerEnv: this.providerEnv ? this.providerEnv : this.network,
           [this.signer]: this.provider,
         }),
       );

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -13,7 +13,7 @@ export class Vault {
   backend: any;
   constructor(params: VaultParameters) {
     this.id = params.id;
-    params.asaVault ? (this.backend = masterVaultAsa) : (this.backend = masterVault);
+    params?.asaVault?.decimals ? (this.backend = masterVaultAsa) : (this.backend = masterVault);
   }
 
   /**

--- a/src/VaultClient.ts
+++ b/src/VaultClient.ts
@@ -9,7 +9,7 @@ export class VaultClient extends Account {
   backend: any;
   constructor(params: AccountInterface) {
     super(params);
-    if (params.asaVault) {
+    if (params?.asaVault?.decimals) {
       this.backend = masterVaultAsa;
     } else {
       this.backend = masterVault;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -16,6 +16,8 @@ export interface AccountInterface {
   network?: 'LocalHost' | 'MainNet' | 'TestNet';
   /** @property An optional instance of the provider object for the signer specified */
   provider?: any;
+  /** @property providerEnv for indexer */
+  providerEnv?: any;
   /** @property An optional instance of the reach standard library */
   reachStdLib?: any;
   /** @property An optional instance of an account from the reach standard library. Used to reconnect via a frontend */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,6 @@
 // @ts-ignore
 import { masterVault, liquidationStaking } from '@xbacked-dao/xbacked-contracts';
 
-const MICRO_UNITS = 1000000;
-
 export const DISCOUNT_RATE = 0.035;
 export const LIQUIDATION_FEE = 0.025;
 
@@ -54,8 +52,9 @@ export const convertFromMicroUnits = (val: number, decimals = 6): number => {
  * @param vaultDebt Vault debt in micro units
  * @returns The maximum amount of debt you can pay to drive the CR back to 120%, considering collateral goes down on each liquidation.
  */
-export const calcMaxDebtPayout = (collateral: number, collateralPrice: number, vaultDebt: number): number => {
+export const calcMaxDebtPayout = (collateral: number, collateralPrice: number, vaultDebt: number, decimals: number): number => {
   const discountRateInv = 1 - DISCOUNT_RATE;
+  const MICRO_UNITS = 10 ** decimals;
   return Math.floor(
     ((discountRateInv * 100 * collateral * collateralPrice) / MICRO_UNITS -
       discountRateInv * (MINIMUM_COLLATERAL_RATIO * 100) * vaultDebt) /
@@ -70,7 +69,8 @@ export const calcMaxDebtPayout = (collateral: number, collateralPrice: number, v
  * @param vaultDebt Vault debt in micro units
  * @returns The vaults current collateral ratio in decimal form (1 = 100%)
  */
-export const calcCollateralRatio = (collateral: number, collateralPrice: number, vaultDebt: number): number => {
+export const calcCollateralRatio = (collateral: number, collateralPrice: number, vaultDebt: number, decimals: number): number => {
+  const MICRO_UNITS = 10 ** decimals;
   return (collateral * collateralPrice) / MICRO_UNITS / vaultDebt;
 };
 
@@ -96,7 +96,9 @@ export const calcCollateralRatioAfterLiquidation = (
   collateralPrice: number,
   debtPayout: number,
   vaultDebt: number,
+  decimals: number,
 ): number => {
+  const MICRO_UNITS = 10 ** decimals;
   const discountPrice = calcDiscountPrice(collateralPrice);
   const collateralAfterLiquidation = collateral - convertToMicroUnits(debtPayout / discountPrice);
   const collateralValueAfterLiquidation = collateralAfterLiquidation * collateralPrice;


### PR DESCRIPTION
- Fixes usage of `MICRO_UNITS`, and now uses `decimals` based on the ASA
- Allows for users of the SDK to provide variables for different node & indexers