### PR TITLE
FIX: Multi Collateral Liquidation bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index",
   "module": "lib/esm/index",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,6 @@
 // @ts-ignore
 import { vault as vaultBackend, stabilityPool } from '@xbacked-dao/xbacked-contracts';
 
-export const DISCOUNT_RATE = 0.035;
-export const LIQUIDATION_FEE = 0.025;
-
 const AMOUNT_OF_SECONDS_IN_YEAR = 31536000;
 const INTEREST_RATE_DENOMINATOR = 100000000000;
 
@@ -71,8 +68,8 @@ export const calcMaxDebtPayout = (
   collateralPrice: number,
   vaultDebt: number,
   decimals: number,
-  minimumCollateralRatio: number = MINIMUM_COLLATERAL_RATIO,
-  discountRate: number = DISCOUNT_RATE,
+  minimumCollateralRatio: number,
+  discountRate: number,
 ): number => {
   const discountRateInv = 1 - discountRate;
   const MICRO_UNITS = 10 ** decimals;
@@ -100,8 +97,8 @@ export const calcCollateralRatio = (collateral: number, collateralPrice: number,
  * @param collateralPrice Collateral price in micro units
  * @returns The discount price for a liquidation in micro units
  */
-export const calcDiscountPrice = (collateralPrice: number): number => {
-  return collateralPrice - collateralPrice * DISCOUNT_RATE;
+export const calcDiscountPrice = (collateralPrice: number, DISCOUNT_RATE: number): number => {
+  return collateralPrice - (collateralPrice * DISCOUNT_RATE);
 };
 
 /**
@@ -118,9 +115,10 @@ export const calcCollateralRatioAfterLiquidation = (
   debtPayout: number,
   vaultDebt: number,
   decimals: number,
+  DISCOUNT_RATE: number,
 ): number => {
   const MICRO_UNITS = 10 ** decimals;
-  const discountPrice = calcDiscountPrice(collateralPrice);
+  const discountPrice = calcDiscountPrice(collateralPrice, DISCOUNT_RATE);
   const collateralAfterLiquidation = collateral - convertToMicroUnits(debtPayout / discountPrice);
   const collateralValueAfterLiquidation = collateralAfterLiquidation * collateralPrice;
   const crAfterLiq = ((collateralValueAfterLiquidation / MICRO_UNITS) * 100) / (vaultDebt - debtPayout);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,23 +61,27 @@ export const convertFromMicroUnits = (val: number, decimals = 6): number => {
  * @param collateral Collateral tokens in micro units
  * @param collateralPrice Current collateral price in micro units
  * @param vaultDebt Vault debt in micro units
+ * @param scaleFactor the amount of decimals the ASA has, default is 6
+ * @param MAXIMUM_LIQUIDATION_CR the maximum CR liquidations can take a vault to
+ * @param DISCOUNT_RATE the vault discount rate 
  * @returns The maximum amount of debt you can pay to drive the CR back to 120%, considering collateral goes down on each liquidation.
  */
-export const calcMaxDebtPayout = (
+ export const maxDebtPayout = (
   collateral: number,
   collateralPrice: number,
   vaultDebt: number,
-  decimals: number,
-  minimumCollateralRatio: number,
-  discountRate: number,
+  scaleFactor = 6,
+  MAXIMUM_LIQUIDATION_CR: number,
+  DISCOUNT_RATE: number
 ): number => {
-  const discountRateInv = 1 - discountRate;
-  const MICRO_UNITS = 10 ** decimals;
-  return Math.floor(
-    ((discountRateInv * 100 * collateral * collateralPrice) / MICRO_UNITS -
-      discountRateInv * (minimumCollateralRatio * 100) * vaultDebt) /
-      (-discountRateInv * (minimumCollateralRatio * 100) + 100),
-  );
+  const discountRateInv = 1 - DISCOUNT_RATE;
+
+  const collateralValue = convertFromMicroUnits(collateral, scaleFactor) * convertFromMicroUnits(collateralPrice);
+  const discountedCollateralValue = discountRateInv * collateralValue;
+  const debtWithPremium = discountRateInv * ((MAXIMUM_LIQUIDATION_CR - 0.01)) * convertFromMicroUnits(vaultDebt);
+  const maxPayment = (discountedCollateralValue - debtWithPremium) / (discountRateInv * (MAXIMUM_LIQUIDATION_CR - 0.01) - 1);
+
+  return Math.abs(maxPayment);
 };
 
 /**
@@ -100,7 +104,6 @@ export const calcCollateralRatio = (collateral: number, collateralPrice: number,
 export const calcDiscountPrice = (collateralPrice: number, DISCOUNT_RATE: number): number => {
   return collateralPrice - (collateralPrice * DISCOUNT_RATE);
 };
-
 /**
  *
  * @param collateral Collateral tokens in micro units
@@ -119,7 +122,7 @@ export const calcCollateralRatioAfterLiquidation = (
 ): number => {
   const MICRO_UNITS = 10 ** decimals;
   const discountPrice = calcDiscountPrice(collateralPrice, DISCOUNT_RATE);
-  const collateralAfterLiquidation = collateral - convertToMicroUnits(debtPayout / discountPrice);
+  const collateralAfterLiquidation = collateral - convertToMicroUnits(debtPayout / discountPrice, decimals);
   const collateralValueAfterLiquidation = collateralAfterLiquidation * collateralPrice;
   const crAfterLiq = ((collateralValueAfterLiquidation / MICRO_UNITS) * 100) / (vaultDebt - debtPayout);
   return crAfterLiq;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,25 +61,25 @@ export const convertFromMicroUnits = (val: number, decimals = 6): number => {
  * @param collateral Collateral tokens in micro units
  * @param collateralPrice Current collateral price in micro units
  * @param vaultDebt Vault debt in micro units
- * @param scaleFactor the amount of decimals the ASA has, default is 6
- * @param MAXIMUM_LIQUIDATION_CR the maximum CR liquidations can take a vault to
- * @param DISCOUNT_RATE the vault discount rate 
+ * @param decimals the amount of decimals the ASA has, default is 6
+ * @param minimumCollateralRatio the maximum CR liquidations can take a vault to
+ * @param discountRate the vault discount rate 
  * @returns The maximum amount of debt you can pay to drive the CR back to 120%, considering collateral goes down on each liquidation.
  */
- export const maxDebtPayout = (
+ export const calcMaxDebtPayout = (
   collateral: number,
   collateralPrice: number,
   vaultDebt: number,
-  scaleFactor = 6,
-  MAXIMUM_LIQUIDATION_CR: number,
-  DISCOUNT_RATE: number
+  decimals: number,
+  minimumCollateralRatio: number,
+  discountRate: number,
 ): number => {
-  const discountRateInv = 1 - DISCOUNT_RATE;
+  const discountRateInv = 1 - discountRate;
 
   const collateralValue = convertFromMicroUnits(collateral, scaleFactor) * convertFromMicroUnits(collateralPrice);
   const discountedCollateralValue = discountRateInv * collateralValue;
-  const debtWithPremium = discountRateInv * ((MAXIMUM_LIQUIDATION_CR - 0.01)) * convertFromMicroUnits(vaultDebt);
-  const maxPayment = (discountedCollateralValue - debtWithPremium) / (discountRateInv * (MAXIMUM_LIQUIDATION_CR - 0.01) - 1);
+  const debtWithPremium = discountRateInv * ((minimumCollateralRatio - 0.01)) * convertFromMicroUnits(vaultDebt);
+  const maxPayment = (discountedCollateralValue - debtWithPremium) / (discountRateInv * (minimumCollateralRatio - 0.01) - 1);
 
   return Math.abs(maxPayment);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ export const convertFromMicroUnits = (val: number, decimals = 6): number => {
 ): number => {
   const discountRateInv = 1 - discountRate;
 
-  const collateralValue = convertFromMicroUnits(collateral, scaleFactor) * convertFromMicroUnits(collateralPrice);
+  const collateralValue = convertFromMicroUnits(collateral, decimals) * convertFromMicroUnits(collateralPrice);
   const discountedCollateralValue = discountRateInv * collateralValue;
   const debtWithPremium = discountRateInv * ((minimumCollateralRatio - 0.01)) * convertFromMicroUnits(vaultDebt);
   const maxPayment = (discountedCollateralValue - debtWithPremium) / (discountRateInv * (minimumCollateralRatio - 0.01) - 1);


### PR DESCRIPTION
Fixes bus in the SDK for calculations related to multi collateral liquidations

- Fixes incorrect maximum calculation. This can still be wrong if interest has not been added to the `vaultDebt` param for a little while

Breaking Changes :warning:
----
- `calcDiscountPrice` now takes a param for discount rates