### PR TITLE
ADD: method to get address from a box

### DIFF
--- a/examples/addrFromBox.js
+++ b/examples/addrFromBox.js
@@ -1,0 +1,8 @@
+const {addrFromBox} = require('..');
+
+const box = {
+  // eslint-disable-next-line max-len
+  name: new Uint8Array([0, 19, 9, 153, 63, 3, 239, 164, 190, 48, 181, 181, 46, 170, 244, 154, 249, 81, 15, 70, 9, 15, 106, 215, 19, 46, 80, 99, 12, 234, 95, 31, 61]),
+};
+
+console.log(addrFromBox(box));

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.22.11",
-    "typescript": "^4.4.4",
+    "typescript": "4.7.4",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1"
   },
@@ -64,6 +64,7 @@
     "@reach-sh/stdlib": "0.1.13-rc.0",
     "@types/jsdom": "^16.2.13",
     "@xbacked-dao/xbacked-contracts": "0.0.27",
+    "algosdk": "^2.0.0",
     "awesome-typescript-loader": "^5.2.1",
     "aws-sdk": "^2.1226.0",
     "axios": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index",
   "module": "lib/esm/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.2.5",
+  "version": "0.2.9",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index",
   "module": "lib/esm/index",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,10 +163,12 @@ export const calculateInterestAccrued = (
 
 // Reach encodes box names following this method: https://docs.reach.sh/networks/#p_8
 export const addrFromBox = (box: any) => {
+  // need to deep copy because otherwise the origial box will be mutated, which the user may not expect
+  const deepCopy = new Uint8Array(box.name.toString().split(','));
   // reverse the bytes so the MapIndex is the last byte
-  box.name.reverse();
+  deepCopy.reverse();
   // remove the last byte in the array
-  const addrBytes = box.name.slice(0, -1);
+  const addrBytes = deepCopy.slice(0, -1);
   // reverse back to original order
   addrBytes.reverse();
   return encodeAddress(addrBytes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { vault as vaultBackend, stabilityPool } from '@xbacked-dao/xbacked-contracts';
+import { encodeAddress } from 'algosdk';
 
 const AMOUNT_OF_SECONDS_IN_YEAR = 31536000;
 const INTEREST_RATE_DENOMINATOR = 100000000000;
@@ -136,15 +137,15 @@ export const getAllAccounts = async (
   nextToken: string,
 ): Promise<any[]> => {
   if (accounts.length > 0 && nextToken) {
-    const retrievedVaults = await indexer.searchAccounts().applicationID(applicationId).nextToken(nextToken).do();
+    const retrievedVaults = await indexer.searchForApplicationBoxes(applicationId).nextToken(nextToken).do();
     const updatedAccounts = accounts.concat(retrievedVaults.accounts);
     return getAllAccounts(applicationId, indexer, updatedAccounts, retrievedVaults['next-token']);
     // eslint-disable-next-line
   } else if (accounts.length > 0 && !nextToken) {
     return Promise.resolve(accounts);
   }
-  const initialVaults = await indexer.searchAccounts().applicationID(applicationId).do();
-  return getAllAccounts(applicationId, indexer, initialVaults.accounts, initialVaults['next-token']);
+  const initialVaults = await indexer.searchForApplicationBoxes(applicationId).do();
+  return getAllAccounts(applicationId, indexer, initialVaults.boxes, initialVaults['next-token']);
 };
 
 export const calculateInterestAccrued = (
@@ -159,6 +160,17 @@ export const calculateInterestAccrued = (
   const interestAccrued = (interestRateOverTimePassed * vaultDebt) / INTEREST_RATE_DENOMINATOR;
   return interestAccrued;
 };
+
+// Reach encodes box names following this method: https://docs.reach.sh/networks/#p_8
+export const addrFromBox = (box: any) => {
+  // reverse the bytes so the MapIndex is the last byte
+  box.name.reverse();
+  // remove the last byte in the array
+  const addrBytes = box.name.slice(0, -1);
+  // reverse back to original order
+  addrBytes.reverse();
+  return encodeAddress(addrBytes);
+}
 
 export const backends = {
   vault: vaultBackend,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,7 @@ __metadata:
     "@types/jsdom": ^16.2.13
     "@types/node": ^16.11.9
     "@xbacked-dao/xbacked-contracts": 0.0.27
+    algosdk: ^2.0.0
     awesome-typescript-loader: ^5.2.1
     aws-sdk: ^2.1226.0
     axios: ^0.26.0
@@ -1687,7 +1688,7 @@ __metadata:
     tslint: ^6.1.3
     tslint-config-prettier: ^1.18.0
     typedoc: ^0.22.11
-    typescript: ^4.4.4
+    typescript: 4.7.4
     webpack: ^5.65.0
     webpack-cli: ^4.9.1
   languageName: unknown
@@ -1882,6 +1883,24 @@ __metadata:
     tweetnacl: ^1.0.3
     vlq: ^2.0.4
   checksum: 3b6960dddec3d7d37a1505dcb3c6997740c5b02fa076a140efcf51eaddd83b7a7c8f56bab3001ec0ac7b1ccdd264e5a41d051b8bf5b9b72762e338c704547203
+  languageName: node
+  linkType: hard
+
+"algosdk@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "algosdk@npm:2.0.0"
+  dependencies:
+    algo-msgpack-with-bigint: ^2.1.1
+    buffer: ^6.0.2
+    cross-fetch: ^3.1.5
+    hi-base32: ^0.5.1
+    js-sha256: ^0.9.0
+    js-sha3: ^0.8.0
+    js-sha512: ^0.8.0
+    json-bigint: ^1.0.0
+    tweetnacl: ^1.0.3
+    vlq: ^2.0.4
+  checksum: bf6ec0144bf0c6e3f80172078cae9db4bba52c2a724e8f8ec1fd520b9a40ced909310729284c1f81dfa0343ec0319447e73a3ffa799367303136024f33f33611
   languageName: node
   linkType: hard
 
@@ -7598,23 +7617,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.4.4":
-  version: 4.9.3
-  resolution: "typescript@npm:4.9.3"
+"typescript@npm:4.7.4":
+  version: 4.7.4
+  resolution: "typescript@npm:4.7.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 17b8f816050b412403e38d48eef0e893deb6be522d6dc7caf105e54a72e34daf6835c447735fd2b28b66784e72bfbf87f627abb4818a8e43d1fa8106396128dc
+  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.4.4#~builtin<compat/typescript>":
-  version: 4.9.3
-  resolution: "typescript@patch:typescript@npm%3A4.9.3#~builtin<compat/typescript>::version=4.9.3&hash=d73830"
+"typescript@patch:typescript@4.7.4#~builtin<compat/typescript>":
+  version: 4.7.4
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=65a307"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 67ca21a387c0572f1c04936e638dde7782c5aa520c3754aadc7cc9b7c915da9ebc3e27c601bfff4ccb7d7264e82dce6d277ada82ec09dc75024349e0ef64926d
+  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes a problem with the latest AVM update with how boxes are retrieved & how accounts are derived from the box name.

⚠️  To fix the build problem, TypeScript needed to be updated, see this issue: https://github.com/algorand/js-algorand-sdk/issues/638