### PR TITLE
ADD: method to derive box name from address

### DIFF
--- a/examples/addrFromBox.js
+++ b/examples/addrFromBox.js
@@ -1,8 +1,21 @@
-const {addrFromBox} = require('..');
+const {addrFromBox, addrToBox} = require('..');
+const {decodeAddress} = require('algosdk');
 
-const box = {
-  // eslint-disable-next-line max-len
-  name: new Uint8Array([0, 19, 9, 153, 63, 3, 239, 164, 190, 48, 181, 181, 46, 170, 244, 154, 249, 81, 15, 70, 9, 15, 106, 215, 19, 46, 80, 99, 12, 234, 95, 31, 61]),
-};
+const addr = 'CMEZSPYD56SL4MFVWUXKV5E27FIQ6RQJB5VNOEZOKBRQZ2S7D46XS6PZ3Y';
 
-console.log(addrFromBox(box));
+console.log(`Address: ${addr}`);
+const boxName = addrToBox(addr);
+console.log(`Box name: ${boxName}`);
+
+const boxNameBytes = new Uint8Array([0, ...decodeAddress(addr).publicKey]);
+
+// eslint-disable-next-line max-len
+const expectedBytes = new Uint8Array([0, 19, 9, 153, 63, 3, 239, 164, 190, 48, 181, 181, 46, 170, 244, 154, 249, 81, 15, 70, 9, 15, 106, 215, 19, 46, 80, 99, 12, 234, 95, 31, 61]);
+
+const box = {name: boxNameBytes};
+
+const derivedAddr = addrFromBox(box);
+console.log(`Address from box: ${derivedAddr}`);
+console.log(`Address from box matches orinal: ${derivedAddr === addr}`);
+// eslint-disable-next-line max-len
+console.log(`Expected bytes match result: ${expectedBytes.toString() === boxNameBytes.toString()}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/xbacked-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Official SDK for the xBacked Protocol",
   "main": "lib/cjs/index",
   "module": "lib/esm/index",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { vault as vaultBackend, stabilityPool } from '@xbacked-dao/xbacked-contracts';
-import { encodeAddress } from 'algosdk';
+import { decodeAddress, encodeAddress } from 'algosdk';
 
 const AMOUNT_OF_SECONDS_IN_YEAR = 31536000;
 const INTEREST_RATE_DENOMINATOR = 100000000000;
@@ -179,6 +179,14 @@ export const addrFromBox = (box: any) => {
   // reverse back to original order
   addrBytes.reverse();
   return encodeAddress(addrBytes);
+}
+
+export const addrToBox = (addr: string) => {
+  const addrBytes = decodeAddress(addr).publicKey;
+  // add a byte to the first position of the array indicating the MapIndex
+  // Reach encodes box names following this method: https://docs.reach.sh/networks/#p_8
+  const boxBytes = new Uint8Array([0, ...addrBytes]);
+  return Buffer.from(boxBytes).toString('base64');
 }
 
 export const backends = {


### PR DESCRIPTION
This method is required to derive the box name when working with remote objects that reference boxes. Run `node examples/addrFromBox.js` to test methods